### PR TITLE
fix figure parsing

### DIFF
--- a/src/Xabbo.Core/Figure/FigurePartType.cs
+++ b/src/Xabbo.Core/Figure/FigurePartType.cs
@@ -31,7 +31,13 @@ public enum FigurePartType
     Coat,
     LeftCoatSleeve,
     RightCoatSleeve,
-    ChestPrint
+    ChestPrint,
+    PetSlot,
+    PetLeft,
+    PetRight,
+    MountCompanion,
+    MountCompanionLeft,
+    MountCompanionRight
 }
 
 public static partial class XabboEnumExtensions
@@ -56,6 +62,12 @@ public static partial class XabboEnumExtensions
             FigurePartType.WaistAccessory => "wa",
             FigurePartType.Coat => "cc",
             FigurePartType.ChestPrint => "cp",
+            FigurePartType.PetSlot => "pt",
+            FigurePartType.PetLeft => "ptl",
+            FigurePartType.PetRight => "ptr",
+            FigurePartType.MountCompanion => "mc",
+            FigurePartType.MountCompanionLeft => "mcl",
+            FigurePartType.MountCompanionRight => "mcr",
             _ => throw new ArgumentException($"Unknown figure part type: {figurePartType}", nameof(figurePartType)),
         };
     }

--- a/src/Xabbo.Core/H.cs
+++ b/src/Xabbo.Core/H.cs
@@ -74,6 +74,12 @@ public static partial class H
             case "lc": partType = FigurePartType.LeftCoatSleeve; break;
             case "rc": partType = FigurePartType.RightCoatSleeve; break;
             case "cp": partType = FigurePartType.ChestPrint; break;
+            case "pt": partType = FigurePartType.PetSlot; break;
+            case "ptl": partType = FigurePartType.PetLeft; break;
+            case "ptr": partType = FigurePartType.PetRight; break;
+            case "mc": partType = FigurePartType.MountCompanion; break;
+            case "mcl": partType = FigurePartType.MountCompanionLeft; break;
+            case "mcr": partType = FigurePartType.MountCompanionRight; break;
             default: partType = default; return false;
         }
         return true;


### PR DESCRIPTION
add support for new figure part types (pt, ptl, ptr, mc, mcl, mcr) from recent figuredata updates